### PR TITLE
Downgrade intl to 0.19.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   flutter_riverpod: ^2.5.1
-  intl: ^0.20.2
+  intl: ^0.19.0
   hive: ^2.2.3
   hive_flutter: ^1.1.0
 


### PR DESCRIPTION
## Summary
- dependencies 업데이트 중 intl 버전을 0.20.2에서 0.19.0으로 변경

## Testing
- `flutter pub get` 시도했으나 환경에 flutter가 없어 실패

------
https://chatgpt.com/codex/tasks/task_e_685bb4384a308328aaba0d4e5c19d3d3